### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,12 @@
 ---
 name: Dependabot Auto-Merge
 
-on: pull_request_target
+on:
+  # zizmor: ignore[dangerous-triggers] — Dependabot PRs get a read-only token under
+  # `pull_request`, so pull_request_target is required to approve and merge them.
+  # Gated to actor == dependabot[bot]; the caller only dispatches the reusable
+  # workflow — no PR-code checkout or exec.
+  pull_request_target:
 
 permissions:
   contents: write

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -2,6 +2,10 @@
 name: Require Linked Issue
 
 on:
+  # zizmor: ignore[dangerous-triggers] — this caller needs pull-requests:write on
+  # fork PRs so the required linked-issue check can post its status/comment; a plain
+  # `pull_request` gives forks a read-only token and the required check deadlocks.
+  # The caller only dispatches the reusable workflow — no PR-code checkout or exec.
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 


### PR DESCRIPTION
Closes #557

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/require-linked-issue.yml
- .github/workflows/dependabot-auto-merge.yml